### PR TITLE
changed tab name to Plan

### DIFF
--- a/prototypes/PlainLanguage2/SectionHeading.html
+++ b/prototypes/PlainLanguage2/SectionHeading.html
@@ -94,7 +94,7 @@ You should totally buy his book on Inclusive Components.
 </section>
 
  <section id="section2">
-<h2>Planning</h2>
+<h2>Plan</h2>
 
 <div class="guidanceBox">
 <h3>Section Headings</h3>

--- a/prototypes/PlainLanguage2/index.html
+++ b/prototypes/PlainLanguage2/index.html
@@ -37,7 +37,7 @@ You should totally buy his book on Inclusive Components.
            <a href="#section4">Develop</a>
         </li>
         <li>
-          <a href="#section5">Test & Audit</a>
+          <a href="#section5">Test and Audit</a>
        </li>
       </ul>
 
@@ -56,7 +56,7 @@ You should totally buy his book on Inclusive Components.
 </section>
 
 <section id="section2">
-<h2>Planning</h2>
+<h2>Plan</h2>
 <div class="guidanceBox">
 <h3>Title</h3>
 	<p>Short description of guidance</p>

--- a/prototypes/PlainLanguage2/template.html
+++ b/prototypes/PlainLanguage2/template.html
@@ -20,7 +20,7 @@ You should totally buy his book on Inclusive Components.
           <a href="#section1">Get Started</a>
         </li>
         <li>
-          <a href="#section2">Planning</a>
+          <a href="#section2">Plan</a>
         </li>
         <li>
            <a href="#section3">Design</a>


### PR DESCRIPTION
Voted in Silver meeting of 15 January to make the tense of the tabs consistent. The group rejected "Planning" for the most simple tense "Plan" on recommendation of COGA members. 