### PR TITLE
Add HTML scoring prototype

### DIFF
--- a/scoring/element/conformance-table.js
+++ b/scoring/element/conformance-table.js
@@ -1,0 +1,26 @@
+import { html, define, store } from 'https://unpkg.com/hybrids@4.3.1/esm/index.js';
+import Scoring from '../scoring.js'
+import wcag3Spec from '../wcag3-spec.js'
+
+export const ConformanceTable = {
+  criticals: () => store.get(Scoring).criticals,
+  lowestScore: () => store.get(Scoring).lowestScore,
+  hasBronze: () => store.get(Scoring).hasBronze,
+  bronzeMinimum: () => wcag3Spec.bronzeMinimumScore,
+
+  render: ({ criticals, lowestScore, hasBronze, bronzeMinimum}) => html`
+    <table>
+      ${ row('Minimum required score for Bronze:', bronzeMinimum) }
+      ${ row('Lowest functional category score:', lowestScore) }
+      ${ row('Critical errors:', criticals) }
+      ${ row('Conformance to Bronze:', hasBronze ? 'yes' : 'no') }
+    </table>
+    <style> @import url("styles/tables.css"); </style>
+  `
+};
+
+const row = (heading, data) => html`
+  <tr> <th>${ heading }</th> <td>${ data }</td> </tr>
+`
+
+define({ ConformanceTable })

--- a/scoring/element/functional-category-list.js
+++ b/scoring/element/functional-category-list.js
@@ -1,0 +1,32 @@
+import { html, define, store } from 'https://unpkg.com/hybrids@4.3.1/esm/index.js';
+import Scoring from '../scoring.js'
+
+export const FunctionalCategoryList = {
+  functionalCategories: () => store.get(Scoring).functionalCategories,
+  render: ({ functionalCategories }) => html`
+    <ul>${ functionalCategories.map((category) => html`
+      <li> <details>
+        <summary>${ functionalSummary(category) }</summary>
+        <ul>${ category.outcomes.map(outcomeLi) }</ul>
+      </details> </li>
+    `)}</ul>
+    <style>
+      ul { list-style: none; }
+      li > details > ul { list-style: circle; }
+    </style>
+  `
+}
+
+const functionalSummary = ({ text, outcomeAverage }) => html`
+  <span>${ text }:</span>&nbsp;
+  <em>${ outcomeAverage }</em>
+`;
+
+const outcomeLi = ({ key, text, averageRate }) => html`
+  <li>
+    <a href="#${key}">${text}:</a>&nbsp;
+    <em>${averageRate}</em>
+  </li>
+`;
+
+define({ FunctionalCategoryList });

--- a/scoring/element/outcome-section.js
+++ b/scoring/element/outcome-section.js
@@ -1,0 +1,34 @@
+import { html, define, store } from 'https://unpkg.com/hybrids@4.3.1/esm/index.js';
+import Scoring from '../scoring.js'
+import './outcome-table.js'
+
+export const OutcomeSection = {
+  outcomeKey: '',
+  outcome: ({ outcomeKey }) => {
+    const { outcomes = [] } = store.get(Scoring)
+    return outcomes.find(({ key }) => key === outcomeKey)
+  },
+
+  render: ({ outcomeKey, outcome = {} }) => html`
+    <section>
+      <h3 id=${outcomeKey}>${outcome.text}</h3>
+      <p>Functional categories: ${outcomeCategories(outcome)}</p>
+      <outcome-table outcomeKey=${outcomeKey}></outcome-table>
+      <p>${outcomeSummary(outcome)}</p>
+    </section>      
+  `
+}
+
+export const outcomeSummary = ({ text, averageRate, criticals }) => html`
+  <em>${text}</em> 
+  has an average rating of <strong>${averageRate}</strong>
+  and <strong>${criticals}</strong> critical issues.
+`
+
+export const outcomeCategories = ({ functionalCategoryNames = [] }) => (
+  functionalCategoryNames.map((name, index, arr) => html`
+    <em>${name}</em>${index + 1 < arr.length ? ',' : ''}&nbsp;
+  `.key(index))
+)
+
+define({ OutcomeSection })

--- a/scoring/element/outcome-table.js
+++ b/scoring/element/outcome-table.js
@@ -1,0 +1,90 @@
+import { html, define, store } from 'https://unpkg.com/hybrids@4.3.1/esm/index.js';
+import Scoring, { updateOutcome, addResult, removeResult } from '../scoring.js'
+
+export const OutcomeTable = {
+  outcomeKey: '',
+  outcome: ({ outcomeKey }) => {
+    const { outcomes = [] } = store.get(Scoring)
+    return outcomes.find(({ key }) => key === outcomeKey) || {}
+  },
+  results: ({ outcome }) => outcome.results,
+  methods: ({ outcome }) => outcome.methods,
+
+  render: ({ results = [], methods, outcomeKey }) => html`
+    <table>
+      <thead>${ tableHeadingRow({ outcomeKey }) }</thead>
+      <tbody>
+        ${results.map((result, resultIndex) => (
+          tableDataRow({ outcomeKey, resultIndex, result, methods })
+        ))}
+      </tbody>
+    </table>
+    <button onclick=${addResult.bind(null, outcomeKey)}>Add a new view</button>
+    <button onclick=${removeResult.bind(null, outcomeKey)}>Remove the bottom view</button>
+    <style> @import url("styles/tables.css"); </style>
+  `
+}
+
+export const tableHeadingRow = ({ outcomeKey }) => html`
+  <tr>
+    <th id="${outcomeKey}-view">URL or view name</th>
+    <th id="${outcomeKey}-method">Method</th>
+    <th id="${outcomeKey}-score">Percentage passed</th>
+    <th id="${outcomeKey}-criticals">Number of critical errors</th>
+    <th id="${outcomeKey}-rating">Rating</th>
+  </tr>
+`
+
+export const tableDataRow = (props) => html`
+  <tr>
+    <td>${ input({ ...props, resultKey: 'view' }) }</td>
+    <td>${ select({ ...props, resultKey: 'method' }) }</td>
+    <td>${ input({ ...props, resultKey: 'score' }) }</td>
+    <td>${ input({ ...props, resultKey: 'criticals' }) }</td>
+    <td> <strong>${outcomeRating(props.result)}</strong> </td>
+  </tr>
+`
+
+const input = ({ outcomeKey, resultIndex, resultKey, result }) => {
+  const value = result[resultKey]
+  const type = typeof value === 'number' ? 'number' : 'text'
+  const labelledby = outcomeKey + '-' + resultKey
+  const oninput = (_, event) => {
+    let { value } = event.target
+    if (type === 'number') {
+      value = parseFloat(value.replace(',', '.')) || 0
+    }
+    updateOutcome({ outcomeKey, resultIndex, resultKey, value })
+  }
+
+  return html`
+    <input type=${type} value=${value} oninput=${oninput} aria-labelledby=${labelledby} />
+  `
+}
+
+const select = ({ outcomeKey, resultKey, result, methods }) => {
+  const selected = result[resultKey]
+  const labelledby = outcomeKey + '-' + resultKey
+  
+  const oninput = (_, event) => {
+    const { value } = event.target
+    updateOutcome({ outcomeKey, resultIndex, resultKey, value })
+  }
+
+  return html`
+    <select aria-labelledby=${labelledby} oninput=${oninput}>
+      ${methods.map((method = {}) => html`
+        <option selected=${method.key === selected}>
+          ${method.text}
+        </option>
+      `)}
+    </select>
+  `
+}
+
+export const outcomeRating = ({ rating }) =>  {
+  const ratingMap = ['Very Poor', 'Poor', 'Fair', 'Good', 'Excellent']
+  return `${ratingMap[rating]} (${rating})`
+}
+
+define({ OutcomeTable })

--- a/scoring/index.html
+++ b/scoring/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WCAG 3.0 Scoring prototype</title>
+</head>
+<body>
+  <h1>WCAG 3.0 Scoring Prototype</h1>
+  <h2>Conformance</h2>
+  <conformance-table></conformance-table>
+
+  <h2>Functional categories</h2>
+  <functional-category-list></functional-category-list>
+
+  <h2>Outcomes</h2>
+  <outcome-section outcome-key="alt-available"></outcome-section>
+  <outcome-section outcome-key="clear-words"></outcome-section>
+
+  <script type="module">
+    import './element/conformance-table.js'
+    import './element/functional-category-list.js'
+    import './element/outcome-section.js'
+  </script>
+</body>
+</html>

--- a/scoring/scoring.js
+++ b/scoring/scoring.js
@@ -1,0 +1,79 @@
+import { store } from 'https://unpkg.com/hybrids@4.3.1/esm/index.js';
+import { storeOutcome, createResult } from './scoring/outcomes.js'
+import wcag3Spec from './wcag3-spec.js'
+
+const Scoring = {
+  outcomes: wcag3Spec.outcomes.map(storeOutcome),
+  functionalCategories: wcag3Spec.functionalCategories.map(storeFunctionalCategories),
+  criticals: ({ outcomes }) => {
+    return outcomes.reduce((sum, { criticals }) => sum + criticals, 0)
+  },
+  lowestScore: ({ functionalCategories }) => {
+    const scores = functionalCategories.map(({ outcomeAverage }) => outcomeAverage)
+    return Math.min(...scores);
+  },
+  hasBronze: ({ criticals, lowestScore }) => {
+    return criticals === 0 && lowestScore >= wcag3Spec.bronzeMinimumScore
+  }
+};
+
+function storeFunctionalCategories(category) {
+  return {
+    ...category,
+    outcomes({ outcomeKeys }) {
+      const { outcomes } = store.get(Scoring)
+      return outcomes.filter(({ key }) => outcomeKeys.includes(key))
+    },
+    outcomeAverage({ outcomes }) {
+      if (outcomes.length === 0) {
+        return 0;
+      }
+      const sum = outcomes.reduce((sum, { averageRate }) => sum + averageRate, 0) || 0;
+      return sum / outcomes.length;
+    }
+  }
+}
+
+export function updateOutcome({ outcomeKey, resultIndex, resultKey, value }) {
+  let { outcomes } = store.get(Scoring)
+  outcomes = replaceOutcome(outcomes, outcomeKey, outcome => ({
+      results: outcome.results.map((result, index) => (
+        index !== resultIndex ? result : { 
+          ...result,
+          [resultKey]: value 
+        }
+      )),
+    }
+  ))
+  store.set(Scoring, { outcomes })
+}
+
+export function addResult(outcomeKey) {
+  let { outcomes } = store.get(Scoring)
+  outcomes = replaceOutcome(outcomes, outcomeKey, outcome => ({
+    results: [
+      ...outcome.results,
+      createResult(outcome)
+    ]
+  }))
+  store.set(Scoring, { outcomes })
+}
+
+export function removeResult(outcomeKey) {
+  let { outcomes } = store.get(Scoring)
+  outcomes = replaceOutcome(outcomes, outcomeKey, ({ results }) => ({
+    results: results.slice(0, results.length - 1)
+  }))
+  store.set(Scoring, { outcomes })
+}
+
+function replaceOutcome(outcomes, outcomeKey, cb) {
+  return outcomes.map(outcome => (
+    outcome.key !== outcomeKey ? outcome : {
+      ...outcome,
+      ...cb(outcome),
+    }
+  ))
+}
+
+export default Scoring;

--- a/scoring/scoring/outcomes.js
+++ b/scoring/scoring/outcomes.js
@@ -1,0 +1,60 @@
+import wcag3Spec from '../wcag3-spec.js'
+
+export function createResult({ ratingMap }) {
+  return {
+    ratingMap,
+    view: 'https://',
+    selectedMethod: '',
+    score: ratingMap[ratingMap.length -1],
+    criticals: 0, 
+    rating: ({ criticals, score, ratingMap }) => {
+      if (criticals) {
+        return 0;
+      }
+      for (let i = ratingMap.length; i >= 0; i--) {
+        if (score >= ratingMap[i - 1]) {
+          return i
+        }
+      }
+      return 0;
+    }
+  }
+}
+
+function outcomeMapping({ key }) {
+  const methods = wcag3Spec.methods.filter(({ outcomeKey }) => outcomeKey === key)
+  const functionalCategories = wcag3Spec.functionalCategories.filter(({ outcomeKeys }) => (
+    outcomeKeys.includes(key)
+  )).map(({ key }) => key)
+
+  return { methods, functionalCategories }
+}
+
+function outcomeGetters() {
+  return {
+    averageRate: ({ results }) => {
+      if (results.length === 0) {
+        return 4;
+      }
+      const sum = results.reduce((sum, { rating }) => sum + rating, 0)
+      return Math.round((sum / results.length) * 10) / 10;
+    },
+    criticals: ({ results }) => {
+      return results.reduce((sum, { criticals }) => sum + criticals, 0) || 0;
+    },
+    functionalCategoryNames({ functionalCategories }) {
+      return functionalCategories.map(key => {
+        return wcag3Spec.functionalCategories.find(category => category.key === key).text
+      })
+    }
+  }
+}
+
+export function storeOutcome(outcome) {
+  return {
+    ...outcome,
+    ...outcomeMapping(outcome),
+    ...outcomeGetters(),
+    results: [createResult(outcome)]
+  }
+}

--- a/scoring/styles/tables.css
+++ b/scoring/styles/tables.css
@@ -1,0 +1,4 @@
+td, th {
+  padding: .2em .5em;
+  text-align: left;
+}

--- a/scoring/wcag3-spec.js
+++ b/scoring/wcag3-spec.js
@@ -1,0 +1,45 @@
+export default {
+  bronzeMinimumScore: 3.5,
+  
+  functionalCategories: [{
+    key: 'vision',
+    text: 'Vision and Visual',
+    outcomeKeys: ['alt-available']
+  }, {
+    key: 'sensory',
+    text: 'Sensory Intersections',
+    outcomeKeys: ['alt-available', 'clear-words']
+  }, {
+    key: 'phys-and-sense',
+    text: 'Physical and Sensory Intersections',
+    outcomeKeys: ['alt-available', 'clear-words']
+  }, {
+    key: 'coga-and-sense',
+    text: 'Cognitive and Sensory Intersections',
+    outcomeKeys: ['alt-available', 'clear-words']
+  }],
+
+  outcomes: [{
+    key: 'alt-available',
+    text: 'Text alternative available',
+    ratingMap: [50, 60, 80, 95]
+  }, {
+    key: 'clear-words',
+    text: 'Uses common and clear words in all content',
+    ratingMap: [1, 1.6, 1.6, 1.7]
+  }],
+
+  methods: [{
+    key: 'img-functional',
+    outcomeKey: 'alt-available',
+    text: 'Text Alternatives for Functional Images (HTML)'
+  }, {
+    key: 'text-img',
+    outcomeKey: 'alt-available',
+    text: 'Text Alternatives for Images of Text (HTML)'
+  }, {
+    key: 'clear-words-all',
+    outcomeKey: 'clear-words',
+    text: 'Use Clear Words (All)'
+  }]
+}


### PR DESCRIPTION
This PR adds an HTML version of the scoring prototype. Some things to note:

1. The data is incomplete. I put all the spec data into wcag3-spec.js, we can add more outcomes / methods / categories as we like.

2. This package uses modern JavaScript, it may not work in older browsers. This can be resolved by adding a build script. My intent was to do this without a build script, since there is no build script currently.

3. There is (almost) no styling in this package. Styles will be handled by the W3C website once incorporated

4. This scoring prototype uses hybrids.js to generate web components