### PR TITLE
Tweak "Success criterion" definition (not "corollary")

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1169,7 +1169,7 @@
 				</dd>
 				<dt><dfn data-lt="Success criteria">Success criterion</dfn></dt>
 				<dd><p>Testable statements that compose the <a>normative</a> aspects of WCAG 2.</p>
-					<p>The closest corollary to success criteria in WCAG 3 is <a href="#outcomes">outcomes</a>.</p></dd>
+					<p>The closest counterpart to success criteria in WCAG 3 are <a href="#outcomes">outcomes</a>.</p></dd>
 				<dt><dfn data-lt="Tests">Test</dfn></dt>
 				<dd>
 					<p>Mechanism to evaluate implementation of a <a>method</a>.</p>


### PR DESCRIPTION
Don't think you mean "corollary" here (as it's not something that follows from/accompanies - see https://www.merriam-webster.com/dictionary/corollary).
A more appropriate, but fancy, word would likely be "analogue" (https://www.merriam-webster.com/dictionary/analogue). But, to keep it a bit simpler/more understandable, "counterpart" may work best.