### PR TITLE
Remove old code, replace with link to repo, etc.

### DIFF
--- a/guidelines/methods/Method-font-characteristic-contrast.html
+++ b/guidelines/methods/Method-font-characteristic-contrast.html
@@ -131,550 +131,16 @@ You should totally buy his book on Inclusive Components.
 <h2>Code Samples</h2>
 
 <h3>Example Code for a Test Tool</h3>	
+	<p><Please see: a href="https://github.com/Myndex/SAPC-APCA">APCA GitHub Repository</a></p>
 <div style="overflow: scroll;  background-color: #FED;">	
 <pre><code>
 ////////////////////////////////////////////////////////////////////////////////
 /////	Functions to parse color values and determine SAPC contrast
-/////	REQUIREMENTS: ECMAScript 6 - ECMAScript 2015
-/////	SAPC tool version 0.97 by Andrew Somers
-/////	https://www.myndex.com/WEB/Perception
-/////	Color value input parsing based substantially on rgbcolor.js by
-/////	Stoyan Stefanov &lt;sstoo@gmail.com&gt;
-/////	His site: http://www.phpied.com/rgb-color-parser-in-javascript/
-/////	MIT license
-////////////////////////////////////////////////////////////////////////////////
-
-////////////////////////////////////////////////////////////////////////////////
-/////
-/////	*****  SAPC BLOCK  *****
-/////
-/////	For Evaluations, this is referred to as: SAPC-7
-/////	sRGB Advanced Perceptual Contrast v0.97 beta JAVASCRIPT
-/////	Copyright Â© 2019 by Andrew Somers
-/////	Licensed to the W3C Per Collaborator Agreement
-/////	SIMPLE VERSION â€” This Version Is Stripped Of Extensions:
-/////		* No Color Vision Module
-/////		* No Spatial Frequency Module
-/////		* No Light Adaptation Module
-/////		* No Dynamics Module
-/////		* No Alpha Module
+/////	
+/////	Please see the APCA GitHub repository for the latest code
+/////   and methods, at: https://github.com/Myndex/SAPC-APCA
 /////
 ////////////////////////////////////////////////////////////////////////////////
-
-
-///// CONSTANTS USED IN THIS VERSION ///////////////////////////////////////////
-
-	const sRGBtrc = 2.218;	// Gamma for sRGB linearization. 2.223 could be used instead
-							// 2.218 sets unity with the piecewise sRGB at #777
-
-	const Rco = 0.2126;		// sRGB Red Coefficient
-	const Gco = 0.7156;		// sRGB Green Coefficient
-	const Bco = 0.0722;		// sRGB Blue Coefficient
-
-	const scaleBoW = 161.8;	// Scaling for dark text on light (phi * 100)
-	const scaleWoB = 161.8;	// Scaling for light text on dark â€” same as BoW, but
-							// this is separate for possible future use.
-
-	const normBGExp = 0.38;		// Constants for Power Curve Exponents.
-	const normTXTExp = 0.43;	// One pair for normal text,and one for REVERSE
-	const revBGExp = 0.5;		// FUTURE: These will eventually be dynamic
-	const revTXTExp = 0.43;		// as a function of light adaptation and context
-
-	const blkThrs = 0.02;	// Level that triggers the soft black clamp
-	const blkClmp = 1.75;	// Exponent for the soft black clamp curve
-
-///// Ultra Simple Basic Bare Bones SAPC Function //////////////////////////////
-
-	// This REQUIRES linearized R,G,B values of 0.0-1.0
-
-function SAPCbasic(Rbg,Gbg,Bbg,Rtxt,Gtxt,Btxt) {
-
-	var	SAPC = 0.0;
-
-	// Find Y by applying coefficients and sum.
-	// This REQUIRES linearized R,G,B 0.0-1.0
-	
-	var	Ybg = Rbg*Rco + Gbg*Gco + Bbg*Bco;
-	var	Ytxt = Rtxt*Rco + Gtxt*Gco + Btxt*Bco;
-
-		/////	INSERT COLOR MODULE HERE	/////
-
-	// Now, determine polarity, soft clamp black, and calculate contrast
-	// Finally scale for easy to remember percentages
-	// Note that reverse (white text on black) intentionally
-	// returns a negative number
-
-	if ( Ybg &gt; Ytxt ) {	///// For normal polarity, black text on white
-
-			// soft clamp darkest color if near black.
-		Ytxt = (Ytxt &gt; blkThrs) ? Ytxt : Ytxt + Math.abs(Ytxt - blkThrs) ** blkClmp;
-		SAPC = ( Ybg ** normBGExp - Ytxt ** normTXTExp ) * scaleBoW;
-		
-		return (SAPC &lt; 15 ) ? "0%" : SAPC.toPrecision(3) + "%";
-		
-	} else {			///// For reverse polarity, white text on black
-
-		Ybg = (Ybg &gt; blkThrs) ? Ybg : Ybg + Math.abs(Ybg - blkThrs) ** blkClmp;
-		SAPC = ( Ybg ** revBGExp - Ytxt ** revTXTExp ) * scaleWoB;
-
-		return (SAPC &gt; -15 ) ? "0%" : SAPC.toPrecision(3) + "%";
-	}
-
-	// If SAPC's more than 15%, return that value, otherwise clamp to zero
-	// this is to remove noise and unusual behavior if the user inputs
-	// colors too close to each other.
-	// This will be more important with future modules. Nevertheless
-	// In order to simplify code, SAPC will not report accurate contrasts
-	// of less than approximately 15%, so those are clamped. 
-	// 25% is the "point of invisibility" for many people.
-
-}
-
-//////////////////////////////////////////////////////////////
-///// END OF SAPC BLOCK             //////////////////////////
-//////////////////////////////////////////////////////////////
-
-
-
-//////////////////////////////////////////////////////////////
-///// sRGB INPUT FORM BLOCK         //////////////////////////
-//////////////////////////////////////////////////////////////
-
-
-function RGBColor(color_string) {
-	
-	this.ok = false;
-
-	// strip any leading #
-	if (color_string.charAt(0) == '#') {	// remove # if any
-		color_string = color_string.substr(1,6);
-	}
-	color_string = color_string.replace(/ /g,'');	// strip spaces
-	color_string = color_string.toLowerCase();		// set lowercase
-
-	// before getting into regexps, try simple matches
-	// and overwrite the input
-
-	var simple_colors = {
-		aliceblue: 'f0f8ff',
-		antiquewhite: 'faebd7',
-		aqua: '00ffff',
-		aquamarine: '7fffd4',
-		azure: 'f0ffff',
-		beige: 'f5f5dc',
-		bisque: 'ffe4c4',
-		black: '000000',
-		blanchedalmond: 'ffebcd',
-		blue: '0000ff',
-		blueviolet: '8a2be2',
-		brown: 'a52a2a',
-		burlywood: 'deb887',
-		cadetblue: '5f9ea0',
-		chartreuse: '7fff00',
-		chocolate: 'd2691e',
-		coral: 'ff7f50',
-		cornflowerblue: '6495ed',
-		cornsilk: 'fff8dc',
-		crimson: 'dc143c',
-		cyan: '00ffff',
-		darkblue: '00008b',
-		darkcyan: '008b8b',
-		darkgoldenrod: 'b8860b',
-		darkgray: 'a9a9a9',
-		darkgreen: '006400',
-		darkkhaki: 'bdb76b',
-		darkmagenta: '8b008b',
-		darkolivegreen: '556b2f',
-		darkorange: 'ff8c00',
-		darkorchid: '9932cc',
-		darkred: '8b0000',
-		darksalmon: 'e9967a',
-		darkseagreen: '8fbc8f',
-		darkslateblue: '483d8b',
-		darkslategray: '2f4f4f',
-		darkturquoise: '00ced1',
-		darkviolet: '9400d3',
-		deeppink: 'ff1493',
-		deepskyblue: '00bfff',
-		dimgray: '696969',
-		dodgerblue: '1e90ff',
-		feldspar: 'd19275',
-		firebrick: 'b22222',
-		floralwhite: 'fffaf0',
-		forestgreen: '228b22',
-		fuchsia: 'ff00ff',
-		gainsboro: 'dcdcdc',
-		ghostwhite: 'f8f8ff',
-		gold: 'ffd700',
-		goldenrod: 'daa520',
-		gray: '808080',
-		green: '008000',
-		greenyellow: 'adff2f',
-		honeydew: 'f0fff0',
-		hotpink: 'ff69b4',
-		indianred : 'cd5c5c',
-		indigo : '4b0082',
-		ivory: 'fffff0',
-		khaki: 'f0e68c',
-		lavender: 'e6e6fa',
-		lavenderblush: 'fff0f5',
-		lawngreen: '7cfc00',
-		lemonchiffon: 'fffacd',
-		lightblue: 'add8e6',
-		lightcoral: 'f08080',
-		lightcyan: 'e0ffff',
-		lightgoldenrodyellow: 'fafad2',
-		lightgrey: 'd3d3d3',
-		lightgreen: '90ee90',
-		lightpink: 'ffb6c1',
-		lightsalmon: 'ffa07a',
-		lightseagreen: '20b2aa',
-		lightskyblue: '87cefa',
-		lightslateblue: '8470ff',
-		lightslategray: '778899',
-		lightsteelblue: 'b0c4de',
-		lightyellow: 'ffffe0',
-		lime: '00ff00',
-		limegreen: '32cd32',
-		linen: 'faf0e6',
-		magenta: 'ff00ff',
-		maroon: '800000',
-		mediumaquamarine: '66cdaa',
-		mediumblue: '0000cd',
-		mediumorchid: 'ba55d3',
-		mediumpurple: '9370d8',
-		mediumseagreen: '3cb371',
-		mediumslateblue: '7b68ee',
-		mediumspringgreen: '00fa9a',
-		mediumturquoise: '48d1cc',
-		mediumvioletred: 'c71585',
-		midnightblue: '191970',
-		mintcream: 'f5fffa',
-		mistyrose: 'ffe4e1',
-		moccasin: 'ffe4b5',
-		navajowhite: 'ffdead',
-		navy: '000080',
-		oldlace: 'fdf5e6',
-		olive: '808000',
-		olivedrab: '6b8e23',
-		orange: 'ffa500',
-		orangered: 'ff4500',
-		orchid: 'da70d6',
-		palegoldenrod: 'eee8aa',
-		palegreen: '98fb98',
-		paleturquoise: 'afeeee',
-		palevioletred: 'd87093',
-		papayawhip: 'ffefd5',
-		peachpuff: 'ffdab9',
-		peru: 'cd853f',
-		pink: 'ffc0cb',
-		plum: 'dda0dd',
-		powderblue: 'b0e0e6',
-		purple: '800080',
-		red: 'ff0000',
-		rosybrown: 'bc8f8f',
-		royalblue: '4169e1',
-		saddlebrown: '8b4513',
-		salmon: 'fa8072',
-		sandybrown: 'f4a460',
-		seagreen: '2e8b57',
-		seashell: 'fff5ee',
-		sienna: 'a0522d',
-		silver: 'c0c0c0',
-		skyblue: '87ceeb',
-		slateblue: '6a5acd',
-		slategray: '708090',
-		snow: 'fffafa',
-		springgreen: '00ff7f',
-		steelblue: '4682b4',
-		tan: 'd2b48c',
-		teal: '008080',
-		thistle: 'd8bfd8',
-		tomato: 'ff6347',
-		turquoise: '40e0d0',
-		violet: 'ee82ee',
-		violetred: 'd02090',
-		wheat: 'f5deb3',
-		white: 'ffffff',
-		whitesmoke: 'f5f5f5',
-		yellow: 'ffff00',
-		yellowgreen: '9acd32'
-	};
-
-	for (var key in simple_colors) {
-		if (color_string == key) {
-			color_string = simple_colors[key];
-		}
-	}
-	// end of simple type-in colors
-
-
-
-	// array of color definition objects
-	var color_defs = [
-		{
-			re: /^rgb\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3})\)$/,
-			example: ['rgb(123, 234, 45)', 'rgb(255,234,245)'],
-			process: function (bits){
-				return [
-					parseInt(bits[1]),
-					parseInt(bits[2]),
-					parseInt(bits[3])
-				];
-			}
-		},
-		{
-			re: /^(\w{2})(\w{2})(\w{2})$/,
-			example: ['#00ff00', '336699'],
-			process: function (bits){
-				return [
-					parseInt(bits[1], 16),
-					parseInt(bits[2], 16),
-					parseInt(bits[3], 16)
-				];
-			}
-		},
-		{
-			re: /^(\w{1})(\w{1})(\w{1})$/,
-			example: ['#fb0', 'f0f'],
-			process: function (bits){
-				return [
-					parseInt(bits[1] + bits[1], 16),
-					parseInt(bits[2] + bits[2], 16),
-					parseInt(bits[3] + bits[3], 16)
-				];
-			}
-		}
-	];
-
-
-
-	// search through the definitions to find a match
-	for (var i = 0; i &lt; color_defs.length; i++) {
-		var re = color_defs[i].re;
-		var processor = color_defs[i].process;
-		var bits = re.exec(color_string);
-		if (bits) {
-			channels = processor(bits);
-			this.r = channels[0];
-			this.g = channels[1];
-			this.b = channels[2];
-			this.ok = true;
-		}
-	}
-
-
-	// validate & cleanup values
-	this.r = (this.r &lt; 0 || isNaN(this.r)) ? 0 : ((this.r &gt; 255) ? 255 : this.r);
-	this.g = (this.g &lt; 0 || isNaN(this.g)) ? 0 : ((this.g &gt; 255) ? 255 : this.g);
-	this.b = (this.b &lt; 0 || isNaN(this.b)) ? 0 : ((this.b &gt; 255) ? 255 : this.b);
-
-
-
-	// some getters
-
-	// returns rgb() value string
-	this.toRGB = function () {
-		return 'rgb(' + this.r + ',' + this.g + ',' + this.b + ')';
-	}
-
-	// returns rgb() value string
-	this.toRGB2 = 'rgb(' + this.r + ', ' + this.g + ', ' + this.b + ')';
-
-
-	// returns hex string
-	this.toHex = function () {
-		var r = this.r.toString(16);
-		var g = this.g.toString(16);
-		var b = this.b.toString(16);
-		if (r.length == 1) r = '0' + r;
-		if (g.length == 1) g = '0' + g;
-		if (b.length == 1) b = '0' + b;
-		return '#' + r + g + b;
-	}
-
-	// returns decimal array for R, G, and B
-	this.toDec = function () {
-		return [this.r/255.0,this.g/255.0,this.b/255.0];
-	}
-
-	// these return linearized R, G, or B
-
-	this.Rlin = function () {
-		return Math.pow(this.r/255.0, sRGBtrc);
-	}
-	this.Glin = function () {
-		return Math.pow(this.g/255.0, sRGBtrc);
-	}
-	this.Blin = function () {
-		return Math.pow(this.b/255.0, sRGBtrc);
-	}
-
-
-	this.toY = function () {
-		return 	Math.pow(this.r/255.0, sRGBtrc) * Rco + Math.pow(this.g/255.0, sRGBtrc) * Gco + Math.pow(this.b/255.0, sRGBtrc) * Bco;
-	}
-}
-
-//////////////////////////////////////////////////////////////
-///// END sRGB INPUT FORM BLOCK 	//////////////////////
-//////////////////////////////////////////////////////////////
-
-</code></pre>
-	</div>
-	
-	<h3>HTML and Page Level Scripts</h3>
-
-	<div style="overflow: scroll; background-color: #DEF;">
-<pre><code>
-
-&lt;?xml version="1.1" encoding="utf-8"?&gt;
-&lt;!DOCTYPE html&gt;
-&lt;head&gt;
-&lt;title&gt;SAPC Contrast Demo&lt;/title&gt;
-
-&lt;script src="SAPCsRGB.js"&gt;
-// Place the above blocks in file SAPCsRGB.js
-&lt;/script&gt;
-
-&lt;script&gt;
-		function getBGColor(s) {
-			var BGcolor = new RGBColor(s);
-			if (BGcolor.ok) {
-			
-				document.getElementById('BGresult').style.backgroundColor
-					= 'rgb(' + BGcolor.r + ', ' + BGcolor.g + ', ' + BGcolor.b + ')';
-				document.getElementById('sansSamples').style.backgroundColor
-					= 'rgb(' + BGcolor.r + ', ' + BGcolor.g + ', ' + BGcolor.b + ')';
-				document.getElementById('serifSamples').style.backgroundColor
-					= 'rgb(' + BGcolor.r + ', ' + BGcolor.g + ', ' + BGcolor.b + ')';
-					
-				document.getElementById('BGresult-text').innerHTML =
-					'&lt;code&gt;&lt;b&gt;HEX:&lt;/b&gt; ' + BGcolor.toHex()
-					  + ' &lt;b&gt;sRGB:&lt;/b&gt; ' + BGcolor.toRGB()
-					  + '&lt;br&gt;&lt;b&gt;Decimal:&lt;/b&gt; rgb( ' + BGcolor.toDec()[0].toPrecision(2)
-					  + ', ' + BGcolor.toDec()[1].toPrecision(2)
-					  + ', ' + BGcolor.toDec()[2].toPrecision(2)
-					  + ' )&lt;br&gt;&lt;b&gt;Lin:&lt;/b&gt; R ' + BGcolor.Rlin().toPrecision(3)
-					  + '&nbsp; G ' + BGcolor.Glin().toPrecision(3)
-					  + '&nbsp; B ' + BGcolor.Blin().toPrecision(3)
-					  + '&lt;br&gt;&lt;b&gt;Luminance:&lt;/b&gt; Y ' + BGcolor.toY().toPrecision(3) + '&lt;/code&gt;'
-					  ;
-			} else {
-				document.getElementById('BGresult-text').innerHTML = 'Invalid Color';
-				document.getElementById('BGresult').style.backgroundColor
-					= 'rgb(255, 255, 255)';
-			}
-		}
-
-		function getTextColor(s) {
-			var textColor = new RGBColor(s);
-			if (textColor.ok) {
-			
-				document.getElementById('textResult').style.backgroundColor
-					= 'rgb(' + textColor.r + ', ' + textColor.g + ', ' + textColor.b + ')';
-				document.getElementById('sansSamples').style.color
-					= 'rgb(' + textColor.r + ', ' + textColor.g + ', ' + textColor.b + ')';
-				document.getElementById('serifSamples').style.color
-					= 'rgb(' + textColor.r + ', ' + textColor.g + ', ' + textColor.b + ')';	
-					
-				document.getElementById('textResult-text').innerHTML =
-					'&lt;code&gt;&lt;b&gt;HEX:&lt;/b&gt; ' + textColor.toHex()
-					  + ' &lt;b&gt;sRGB:&lt;/b&gt; ' + textColor.toRGB()
-					  + '&lt;br&gt;&lt;b&gt;Decimal:&lt;/b&gt; rgb( ' + textColor.toDec()[0].toPrecision(2)
-					  + ', ' + textColor.toDec()[1].toPrecision(2)
-					  + ', ' + textColor.toDec()[2].toPrecision(2)
-					  + ' )&lt;br&gt;&lt;b&gt;Lin:&lt;/b&gt; R ' + textColor.Rlin().toPrecision(3)
-					  + '&nbsp; G ' + textColor.Glin().toPrecision(3)
-					  + '&nbsp; B ' + textColor.Blin().toPrecision(3)
-					  + '&lt;br&gt;&lt;b&gt;Luminance:&lt;/b&gt; Y ' + textColor.toY().toPrecision(3) + '&lt;/code&gt;'
-					  ;
-			} else {
-				document.getElementById('textResult-text').innerHTML = 'Invalid Color';
-				document.getElementById('textResult').style.backgroundColor = 'rgb(255, 255, 255)';
-			}
-		}
-		
-	&lt;/script&gt;
-&lt;/head&gt;
-&lt;body onLoad="document.getElementById('inputBG').focus(); document.getElementById('inputText').focus(); document.getElementById('inputBG').focus(); testContrast(); "&gt;
-
-	&lt;div id="demoArea"&gt; 
-	
-		&lt;div id="contrast"&gt;        
-			&lt;div id="contrastLabel"&gt;SAPC Contrast&lt;/div&gt;
-			&lt;div id="contrastResult"&gt;NaN&lt;/div&gt;
-        &lt;/div&gt;
-       
-        &lt;h1 style="text-align: left; "&gt;SAPC Visual Contrast Demo&lt;/h1&gt;
-
-        &lt;div class=""&gt;
-			This is the Basic SAPC contrast method using JavaScript. 
-			&lt;br&gt;Just type in color values as #hex, rgb(), or HTML name 
-			&lt;br&gt;then navigate away from the input field by either
-			&lt;br&gt;pressing TAB or clicking elsewhere on the page.
-        &lt;/div&gt;
-    &lt;/div&gt;           
-
-
-	&lt;div id="inputArea"&gt;        
-		&lt;div style="position: relative; float: left;"&gt;
-			&lt;h3&gt;ENTER BACKGROUND COLOR
-			&lt;/h3&gt;
-			&lt;form id="colorForm" name="colorForm" onsubmit="getBGColor(this.elements[0].value); getTextColor(this.elements[1].value); return false;"&gt;
-				&lt;div class="input"&gt;
-					&lt;input
-						id="inputBG"
-						type="text"
-						value="#BA9"
-						onblur="getBGColor(this.value); testContrast();"&gt;
-				&lt;/div&gt;
-		
-			&lt;div id="BGresult-wrap"&gt;&lt;div id="BGresult"&gt;&lt;/div&gt;&lt;/div&gt;
-			&lt;div class="codeBlock" id="BGresult-text"&gt;&lt;/div&gt;
-	   &lt;/div&gt;
-	
-        
-		&lt;div style="position: relative; float: right;"&gt;
-			&lt;h3&gt;ENTER TEXT COLOR
-			&lt;/h3&gt;
-				&lt;div class="input"&gt;
-					&lt;input
-						id="inputText"
-						type="text"
-						value="#319"
-						onblur="getTextColor(this.value); testContrast();"&gt;
-				&lt;/div&gt;
-			&lt;/form&gt;
-			&lt;div id="textResult-wrap"&gt;&lt;div id="textResult"&gt;&lt;/div&gt;&lt;/div&gt;
-			&lt;code id="textResult-text"&gt;&lt;/code&gt;
-	
-		&lt;/div&gt;
-	&lt;/div&gt;
-
-&lt;div style="font-size: 12px;"&gt;The page and code is Copyright © 2020 by Andrew Somers.
-&lt;br&gt;Licensed to the W3.org per their cooperative agreement. 
-&lt;br&gt;Otherwise under the MIT license. 
-&lt;br&gt;Repository: &lt;a href="https://github.com/Myndex/SAPC/tree/master/JS"&gt;https://github.com/Myndex/SAPC/tree/master/JS&lt;/a&gt;
-&lt;br&gt;Color value input parsing based substantially on rgbcolor.js by
-&lt;br&gt;Stoyan Stefanov &lt;sstoo@gmail.com&gt; used per MIT license.
-&lt;br&gt;
-This project is part of the &lt;a href="https://www.myndex.com/WEB/Perception"&gt;Myndex Web Perception Experiment.
-&lt;/a&gt;
-&lt;br&gt;&lt;br&gt;
-    &lt;span onclick="testContrast()" style="cursor: pointer; text-decoration: underline"&gt;Manual Refresh&lt;/span&gt;
-
-&lt;script&gt;
-	function testContrast() {
-		var BG = new RGBColor(document.getElementById('inputBG').value);
-		var txt = new RGBColor(document.getElementById('inputText').value);
-		
-		document.getElementById('contrastResult').innerHTML =  SAPCbasic(BG.Rlin(),BG.Glin(),BG.Blin(),txt.Rlin(),txt.Glin(),txt.Blin());
-	}
-&lt;/script&gt;		
-&lt;/body&gt;
-&lt;/html&gt;
-
 </code>
 </pre>
 
@@ -805,16 +271,23 @@ This project is part of the &lt;a href="https://www.myndex.com/WEB/Perception"&g
 		<li>Convert the sRGB background and text colors to luminance Ybg and Ytxt
 		<ul>
 			<li>Convert from 8 bit integer to decimal 0.0-1.0
-			<li>Linearize (remove gamma)
+			<li>Linearize (remove gamma) by applying a ^2.218 exponent
 			<li>Apply sRGB coefficients and sum to Y<br>
 			<img src="images/sRGBcoefficients.png">
 					
 		</ul>	
 		<li>Determine which is brighter for contrast polarity
-		<li>Apply pre-process modules (clamp, <em>FUTURE: color, spatial, adaptation</em>)
-		<li>Apply power curve exponents for perceptual lightness
-		<li>Find difference and scale to output percentage	
+		<li>Apply pre-process modules (Black level soft clamp)
+		<li>Apply power curve exponents for perceptual ccontrast
+			<ul>
+			<li>For dark text on a light background, use ^0.43 for the text and ^0.39 for the background.
+			<li>For light text on a dark background, use ^0.43 for the text and ^0.5 for the background.
+			</ul>
+		<li>Find difference between text and background then multiply by phi (1.618) to scale output contrast value.
 	</ul>
+
+<p>Please see the <a href="https://github.com/Myndex/SAPC-APCA">APCA GitHub Repository</a> for the latest code and methods, at <a href="https://github.com/Myndex/SAPC-APCA">https://github.com/Myndex/SAPC-APCA</a>.</p>				
+
 	
 	<h2>Basic APCA Math Pseudocode</h2>	
 
@@ -840,37 +313,41 @@ This project is part of the &lt;a href="https://www.myndex.com/WEB/Perception"&g
 <dl id="dfn-relative-contrast">
   <h3>Predicted Contrast</h3>
   <dd>
-    <p>The Predicted Visual Contrast (<var>APCA</var>) between a foreground color and a background color is expressed as a percentange and is calculated by:</p>
+    <p>The Predicted Visual Contrast (<var>APCA</var>) between a foreground color and a background color is calculated by:</p>
 	 
 <pre>
 //  Define Constants for Basic APCA Version:
 
+sRGBtrc = 2.218;	// Linearization exponent**
+
 normBGExp = 0.38;	// Constants for Power Curve Exponents.
-normTXTExp = 0.43;	// One pair for normal text, and one for REVERSE
-revBGExp = 0.5;		// FUTURE: These will eventually be dynamic
-revTXTExp = 0.43;	// as a function of light adaptation and context
+normTXTExp = 0.43;	// One pair for normal text, dark text on light BG
+revBGExp = 0.5;		// and one for reverse, light text on dark BG
+revTXTExp = 0.43;
+
+scale = 1.618;          // Scale output for easy to remember levels
 
 blkThrs = 0.02;		// Level that triggers the soft black clamp
-blkClmp = 1.75;		// Exponent for the soft black clamp curve
+blkClmp = 1.33;		// Exponent for the soft black clamp curve
 
 //  Calculate Predicted Contrast and return a string for the result
 
 if Y<sub>bg</sub> &gt; Y<sub>txt</sub> then {
     Y<sub>txt</sub> = (Y<sub>txt</sub> > blkThrs) ? Y<sub>txt</sub> : Y<sub>txt</sub> + abs(Y<sub>txt</sub> - blkThrs) ^ blkClmp;
-    APCA = ( Y<sub>bg</sub> ^ normBGExp - Y<sub>txt</sub> ^ normTXTExp ) * 161.8;
-    return (APCA < 15 ) ? "0%" : str(APCA) + "%";
+    APCA = ( Y<sub>bg</sub> ^ normBGExp - Y<sub>txt</sub> ^ normTXTExp ) * scale;
+    return (APCA < 0.12 ) ? "LOW" : str(APCA * 100) + " Lc";
   } else {
     Y<sub>bg</sub>g = (Y<sub>bg</sub> > blkThrs) ? Y<sub>bg</sub> : Y<sub>bg</sub> + abs(Y<sub>bg</sub> - blkThrs) ^ blkClmp;
-    APCA = ( Y<sub>bg</sub> ^ revBGExp - Y<sub>txt</sub> ^ revTXTExp ) * 161.8;
-    return (APCA > -15 ) ? "0%" : str(APCA) + "%";
+    APCA = ( Y<sub>bg</sub> ^ revBGExp - Y<sub>txt</sub> ^ revTXTExp ) * scale;
+    return (APCA > -0.12 ) ? "-LOW" : str(APCA * 100) + " Lc";
 }  
     </pre>
 
   </dd>
 </dl>
 <div><span><em>Notes:</em></span><smaller>
-  <p>Predicted contrast less than 15% is clamped to zero to simplify the math. </p>
-  <p><em>We will use the simple exponent, and not the piecewise sRGB transfer curve, as we are emulating display gamma and not performing image processing.</em> 
+  <p>Predicted contrast less than 12% is clamped to zero to simplify the math. </p>
+  <p><em>**We will use the simple exponent, and not the piecewise sRGB transfer curve, as we are emulating display gamma and not performing image processing.</em> 
 </p><p>The &ldquo;^&rdquo; character is the exponentiation operator.</p>
 </smaller>	
 </div>


### PR DESCRIPTION
It came to my attention that people are still using this page via [GitHub.io](https://w3c.github.io/silver/guidelines/methods/Method-font-characteristic-contrast.html), but since all of this information was deleted from the FPWD, it is important that this page be current to prevent misunderstandings (some have already occured).

This commit deletes the old obsolete sampleJS code (under "code samples"), corrects some important values in the plain language tutorial & pseudocode (under the "resources" tab), and provides **links to the GitHub repo** for the authoritative APCA code and methods.

Thank you,

Andy