### PR TITLE
Clear Words Intro – Fix list

### DIFF
--- a/how-tos/clear-words/get-started.html
+++ b/how-tos/clear-words/get-started.html
@@ -16,7 +16,10 @@
 					<li>Define words</li>
 					<li>Simple tense </li>
 					<li>Literal language</li>
-					<li>Avoid double negatives</li>
+				</ul>
+				<p>Avoid:</p>
+				<ul>
+					<li>Double negatives</li>
 					<li>Nested clauses</li>
 					<li>Diacritical marks (such as è, ñ, ç)</li>
 				</ul>


### PR DESCRIPTION
Fix list to make its words clearer. I have some quibbles with “don’t use diacritical marks”, because they can be important for words from other languages or when used in names. I think a simple “avoid” is maybe reaching too far. Maybe it could be “Avoid lean words.” or “Avoid words with glyphs uncommon to the used language.”