### PR TITLE
Fix image accessible name issues

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -87,7 +87,7 @@
 				<p>Some of these sections are in this document. You can find others in links within the sections.</p>
 			</details>
 			<figure id="guidelines-structure-diagram" aria-labelledby="guidelines-structure-description" class="figure-float">
-				<img src="img/structure-core.svg" />
+				<img src="img/structure-core.svg" alt="" />
 				<figcaption>Core Structure</figcaption>
 			</figure>
 			<p><a href="#guidelines-structure-diagram">Figure 1</a> shows <span id="guidelines-structure-description">the core structure of WCAG 3.0. WCAG 3.0 has three levels of content with associated documentation. Guidelines form the top level. Each guideline contains multiple outcomes, with associated critical errors and outcomes scoring. Each outcome contains multiple methods, with an associated description and examples, tests, and test scoring.</span></p>
@@ -125,7 +125,7 @@
 				<section>
 					<h3>Methods structure</h3>
 					<figure id="method_screenshot" aria-labelledby="method_screenshot_description" class="figure-float screenshot">
-						<img src="img/method.png" />
+						<img src="img/method.png" alt="" />
 							<figcaption>Screenshot of a Method for Structured Content</figcaption>
 					</figure>
 					<p>Each outcome has one or more <a href="#methods-structure">methods</a>. There are three types of methods:</p>
@@ -179,15 +179,15 @@
 
 		<p>The core structure has inter-relationships with supporting documents and the scoring process. <span id="guidelines--full-structure-description"> Functional needs inform both outcomes and functional categories. The tests within methods are used to inform the scores for each outcome. Then outcome scores are aggregated to create scores by functional category and an overall score. These then result in a bronze rating.  Silver and gold ratings build on the bronze rating to demonstrate improved accessibility. General information about guidelines is available in How To documents. </span></p>
 			<figure id="guidelines-full-structure-diagram" aria-labelledby="guidelines--full-structure-description" class="figure-full">
-				<img src="img/structure-scoring.svg" />
+				<img src="img/structure-scoring.svg" alt="" />
 				<figcaption>Documentation and Scoring Structure</figcaption>
 			</figure>
 				<section>
 					<h3>How tos</h3>
 					<p>The <a>How-To</a> content provides explanatory material for each guideline that applies across technologies. This guidance explains how to apply the concepts presented in the guidelines for non-technical readers. This plain language resource includes information on getting started, who the guideline helps and how, as well information for project managers, designers and developers.  </p>
 					<figure id="howTo_screenshot" aria-labelledby="howTo_screenshot_description" class="figure-float screenshot">
-						<img src="img/how-to.png" />
-							<figcaption>Example screenshot of a How-To for Structured Content</figcaption>
+						<img src="img/how-to.png" alt="" />
+						<figcaption>Example screenshot of a How-To for Structured Content</figcaption>
 					</figure>
 					<p id="howTo_screenshot_description">The example of a How-To for Structured Content provides basic information organized by tabs to help people get started with accessibility for structured content, plan for implementing accessible structured content across a project, design accessible structured content, and basics for developers new to accessibility of structured content. It also includes information on examples, the outcomes for meeting the guideline, and resources.</p>
 				</section>


### PR DESCRIPTION
Suspect this may have come from a misunderstanding of how figure works. Just because something is in a figure, doesn't mean it'll be ignored. If you want the images ignored, which I think is the intent, they need an empty alt (or role=none).