### PR TITLE
Remove levels references

### DIFF
--- a/outcomes/headings-organize-content.html
+++ b/outcomes/headings-organize-content.html
@@ -1,13 +1,15 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>Outcome: Headings with levels organize content</title>
+		<title>Outcome: Headings meaningfully organize content</title>
 	</head>
 	<body>
 		<main>
-			<h1>Outcome: Headings with levels organize content</h1>
-			<p class="outcome">Organizes content into logical blocks with both heading text and level relevant to the subsequent content to make locating and navigating information easier and faster.</p>
-			<p>This outcome relates to guideline <a href="http://w3c.github.io/silver/guidelines/#structured-content-outcome-headings-with-levels-organize-content" class="guideline-link">Structured content</a>.</p>
+			<h1>Outcome: Headings meaningfully organize content</h1>
+			<p class="outcome">Organize content into logical blocks with heading text relevant to the subsequent content to make locating and navigating information easier and faster.</p>
+			
+			<p>This outcome relates to guideline <a href="http://w3c.github.io/silver/guidelines/#structured-content" class="guideline-link">Structured content</a>.</p>
+			
 			<p>Methods:</p>
 			<ol>
 				<li><a class="method-link" href="https://www.w3.org/WAI/GL/WCAG3/2020/methods/relevant-headings/">Relevant headings (All)</a></li>


### PR DESCRIPTION
In order to keep Outcomes technology neutral, removed the references to levels, since that isn't possible for some technology. cc @jspellman