### PR TITLE
Match refs to WCAG 3.0 in This Explainer list

### DIFF
--- a/explainer/index.html
+++ b/explainer/index.html
@@ -79,7 +79,7 @@
 	  <p>This Explainer includes: </p>
 		<ul>
 			<li>background information on the development of WCAG 3.0;</li>
-			<li>goals for WCAG3;</li>
+			<li>goals for WCAG 3.0;</li>
 			<li>explanation of design decisions;</li>
 			<li>and differences from the current WCAG 2 guidelines to make it easier for people to understand the changes. </li> 
 		</ul>


### PR DESCRIPTION
Make the references to WCAG 3.0 match in the This Explainer includes list.