### PR TITLE
move status filter to non-removed script

### DIFF
--- a/guidelines/guidelines.js
+++ b/guidelines/guidelines.js
@@ -165,38 +165,6 @@ function addStatusMarkers() {
 	});
 }
 
-function enableStatusFilter() {
-	var filterActive = false;
-	var button = document.querySelector('#status-filter');
-	var statusLabels = (button.getAttribute('data-status-filter') || '').split(',');
-	var statusSelector = statusLabels.map(function (status) {
-		return '[data-status="'+ status +'"]'
-	}).join(',')
-
-	function toggleStatus() {
-		filterActive = !filterActive; // Toggle
-		var sections = document.querySelectorAll(statusSelector);
-		sections.forEach(function (section) {
-			if (section.hasAttribute('data-no-filter')) {
-				return; // Use this to override the filter
-			}
-			var sectionId = section.id || findHeading(section).id;
-			var tocLink = document.querySelector('#toc a[href="#' + sectionId + '"]'); // this may be null due to TOC depth limit
-			var tocItem = tocLink == null ? null : tocLink.parentNode;
-			if (filterActive) {
-				section.setAttribute('hidden', '');
-				if (tocItem != null) tocItem.setAttribute('hidden', '');
-			} else {
-				section.removeAttribute('hidden');
-				if (tocItem != null) tocItem.removeAttribute('hidden');
-			}
-		});
-		button.textContent = (filterActive ? 'Reveal' : 'Hide') + ' placeholder & exploratory sections';
-	}
-	button.addEventListener('click', toggleStatus);
-	toggleStatus(); // Active by default
-}
-
 function termTitles() {
 	// put definitions into title attributes of term references
 	document.querySelectorAll('.internalDFN').forEach(function(node){
@@ -369,5 +337,4 @@ function postRespec() {
 	addNoteMarkers();
 	removeImgSize();
 	outputJson();
-	enableStatusFilter();
 }

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -6,6 +6,7 @@
 		<script src="guidelines.js" class="remove"></script>
 		<script src="respec-config.js" class="remove"></script>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script src="wcag3.js"></script>
 		<link rel="stylesheet" type="text/css" href="guidelines.css" />
 	</head>
 	<body>

--- a/guidelines/wcag3.js
+++ b/guidelines/wcag3.js
@@ -1,0 +1,35 @@
+function enableStatusFilter() {
+	var filterActive = false;
+	var button = document.querySelector('#status-filter');
+	var statusLabels = (button.getAttribute('data-status-filter') || '').split(',');
+	var statusSelector = statusLabels.map(function (status) {
+		return '[data-status="'+ status +'"]'
+	}).join(',')
+
+	function toggleStatus() {
+		filterActive = !filterActive; // Toggle
+		var sections = document.querySelectorAll(statusSelector);
+		sections.forEach(function (section) {
+			if (section.hasAttribute('data-no-filter')) {
+				return; // Use this to override the filter
+			}
+			var sectionId = section.id || findHeading(section).id;
+			var tocLink = document.querySelector('#toc a[href="#' + sectionId + '"]'); // this may be null due to TOC depth limit
+			var tocItem = tocLink == null ? null : tocLink.parentNode;
+			if (filterActive) {
+				section.setAttribute('hidden', '');
+				if (tocItem != null) tocItem.setAttribute('hidden', '');
+			} else {
+				section.removeAttribute('hidden');
+				if (tocItem != null) tocItem.removeAttribute('hidden');
+			}
+		});
+		button.textContent = (filterActive ? 'Reveal' : 'Hide') + ' placeholder & exploratory sections';
+	}
+	button.addEventListener('click', toggleStatus);
+	toggleStatus(); // Active by default
+}
+
+window.addEventListener('load', (event) => {
+  enableStatusFilter();
+});


### PR DESCRIPTION
Moves the script that makes the status filter work to a new .js file that doesn't get cleaned out after Respec is done