### PR TITLE
re-enable status filter

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -6,7 +6,7 @@
 		<script src="guidelines.js" class="remove"></script>
 		<script src="respec-config.js" class="remove"></script>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<!--<script src="wcag3.js"></script>-->
+		<script src="wcag3.js"></script>
 		<link rel="stylesheet" type="text/css" href="guidelines.css" />
 	</head>
 	<body>


### PR DESCRIPTION
status filter was suppressed in https://github.com/w3c/silver/pull/624/commits/95f74daa3c0a9fd015de3d20152c88b88ee0cc03 but should have been re-enabled on merge