### PR TITLE
add equity section

### DIFF
--- a/requirements/index.html
+++ b/requirements/index.html
@@ -130,6 +130,35 @@
 							<strong>Governance</strong>: Utilize tools that allow interested parties to predict when issues important to them are being discussed. Maintain a backlog that reflects issues along with their status. </li>
 					</ul>
 				</section>
+			<section class="exploratory">
+				<h4>Equity</h4>
+				<div class="ednote">
+					<p>This section is exploratory. Outstanding questions that need to be addressed include:</p>
+					<ul>
+						<li>Should Equity assist in uptake of WCAG3 by regulators?</li>
+						<li>How do we incorporate guidance for functional needs for which we lack expertise in the group?</li>
+						<li>How can we add guidance for technological solutions that don’t yet exist?</li>
+						<li>How do we make WCAG conformance realistically adoptable for various organization types?</li>
+						<li>How do we address circumstances where user groups have conflicting needs?</li>
+						<li>Could including more functional categories get a better score and less functional categories would get a poorer score? Would that improve equity or reduce it in practice?</li>
+						<li>How can we make the use of the guidelines equitable across user needs (i.e., a blind person being able to caption or judge color contrast)?</li>
+						<li>In a guideline specification, how far can we go to support socioeconomic impact on people with disabilities?</li>
+						<li>How can we ensure that we are in alignment with various international civil rights legislation?</li>
+						<li>How do we balance intersecting dimensions of equity? For instance, we might consider equity in context of population size or proportion addressed, technical difficulty or cost of solutions, degree of importance to users, verifiability of conformance, etc. Increasing equity in one dimension could involve trade-offs in others.</li>
+					</ul>
+				</div>
+				<p>The term “equity” refers to the ability of people with diverse characteristics to access and understand content, and to participate effectively in processes. Web accessibility guidelines seek to increase equity for people with disabilities by ensuring supports are provided for people with different functional needs. Work towards equity considers three layers:</p>
+				<ul>
+					<li><strong>Equity in impact</strong>: WCAG 3 aims to improve accessibility of web content for users with diverse functional needs. The goal of equity in impact is to ensure that relevant user groups do not find their needs overlooked or less well covered than other groups. This aims to ensure that sites conforming to WCAG 3 are equivalently accessible to all.</li>
+					<li><strong>Equity in process</strong>: The process of developing WCAG 3 requires equity to be an active part of the working group process. It is important to enable broad participation by seeking broad participation, welcoming contributors, respecting viewpoints, accommodating language fluency and comprehension differences, using accessible tools and providing reasonable support if needed, and supporting multiple modes of interaction and discussion. </li>
+					<li><strong>Structural equity</strong>: Inequity can be caused or reinforced by social systems, such as prevailing beliefs, laws and regulations, and institutional patterns. These constitute a context of equity challenges for the process and impact of WCAG 3 that need to be considered. While structural equity is outside the direct scope of W3C standards, the impact of WCAG 3 can be a part of structural equity solutions.</li>
+				</ul>
+				<p class="note">The primary scope for WCAG 3 is to address equity for persons with disabilities. Efforts towards equity must, however, take into account all types of human difference. This includes but is not limited to gender, gender identity and gender expression, sexual orientation, disability (both visible and invisible), mental health, neurotype, physical appearance, body, age, race, socio-economic status, ethnicity, caste, nationality, language, or religion.</p>
+				<p>“Equity” as a noun is a hypothetical or target state, not one that will necessarily be fully reached in practice. Equity is distinct from <i>equality</i>, in that equity focuses on equivalent results, whereas equality only provides similar opportunities. An equitable practice may provide minimal supports for many users, moderate for others, and extensive for some, in order for all of them to be able to complete a task with comparable facility. Requirements for equity are informed by the nature of <em>inequities</em> that exist.</p>
+				<p>An “equity-centered process” aims to make meaningful progress towards the goal of reducing inequity. The Accessibility Guidelines Working Group’s participatory design approach requires involvement from people across the spectrum of functional needs, with appropriate supports for ongoing building of awareness, trust in each other, and ownership of personal responsibility in the process. It also requires accountability to the process and results, in the form of cyclical progress reviews and goal updates.</p>
+				<p>The Accessibility Guidelines Working Group maintains an <a href="https://github.com/w3c/silver/wiki/Equity-Framework">Equity Framework</a> which documents the group’s goals for equity with concrete plans to achieve them. The equity framework must be considered in technical decisisions about the design of WCAG 3, such as expanded test types and identification of functional needs. It also informs equity in the group’s process, and where appropriate identifies relationships to structural equity issues. The group must conduct periodic reviews of progress towards equity in impact and process, identifying ongoing or new barriers and proposing solutions.</p>
+				<p class="ednote">This proposal involves a restructure of the wiki page at the equity framework link, moving most of the current content to side resources and focusing it on identified issues, concrete plans, and progress reviews.</p>
+			</section>
 			</section>
 		<section>
 		  <h2 id="design_principles">Design Principles</h2>


### PR DESCRIPTION
Add a section on equity to the requirements, identifying it as an opportunity of WCAG 3 but also describing what we need to do to meet that opportunity. To keep length comparable to other sections, it touches on the points considered by the equity sub-group in a highly condensed way, then offsets the rest to the Equity Framework document.